### PR TITLE
Add clue grid rendering in batch processing

### DIFF
--- a/batching.py
+++ b/batching.py
@@ -8,9 +8,10 @@ from typing import List
 import numpy as np
 from PIL import Image
 
-from nonogram_clues import load_grid, extract_clues
+from nonogram_clues import load_grid, extract_clues, puzzle_from_image
 from nonogram_solver import solve_nonogram
 from adapt_puzzle import grid_from_array, adapt_grid_for_unique_solution
+from clue_grid import render_clue_grid
 
 
 def validate_or_adapt(puzzle_path: str) -> bool:
@@ -84,7 +85,12 @@ def batch_process_images() -> None:
                 try:
                     print(f"  Creating {method_name} (grid {grid_size})...")
                     subprocess.run(cmd, check=True, capture_output=True)
-                    if not validate_or_adapt(str(output_file)):
+                    if validate_or_adapt(str(output_file)):
+                        puzzle = puzzle_from_image(str(output_file))
+                        clue_img = render_clue_grid(puzzle.clues_row, puzzle.clues_col)
+                        clue_path = output_folder / f"{method_name}_grid{grid_size}_clues.png"
+                        clue_img.save(clue_path)
+                    else:
                         output_file.unlink(missing_ok=True)
                         bad_log.write(f"{image_path} - {method_name} grid{grid_size} invalid\n")
                         print("    Invalid puzzle, logged.")

--- a/clue_grid.py
+++ b/clue_grid.py
@@ -1,0 +1,39 @@
+from typing import List
+from PIL import Image, ImageDraw, ImageFont
+
+
+def render_clue_grid(row_clues: List[List[int]], col_clues: List[List[int]], cell_size: int = 20) -> Image.Image:
+    """Return an image visualizing the puzzle clues."""
+    rows, cols = len(row_clues), len(col_clues)
+    row_pad = max(len(c) for c in row_clues)
+    col_pad = max(len(c) for c in col_clues)
+
+    width = (row_pad + cols) * cell_size
+    height = (col_pad + rows) * cell_size
+    img = Image.new("RGB", (width, height), "white")
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.load_default()
+
+    # Draw grid lines
+    for i in range(rows + 1):
+        y = (col_pad + i) * cell_size
+        draw.line([(row_pad * cell_size, y), (width, y)], fill="gray")
+    for j in range(cols + 1):
+        x = (row_pad + j) * cell_size
+        draw.line([(x, col_pad * cell_size), (x, height)], fill="gray")
+
+    # Draw row clues
+    for i, clues in enumerate(row_clues):
+        for k, num in enumerate(reversed(clues)):
+            x = (row_pad - 1 - k) * cell_size + 4
+            y = (col_pad + i) * cell_size + 4
+            draw.text((x, y), str(num), fill="black", font=font)
+
+    # Draw column clues
+    for j, clues in enumerate(col_clues):
+        for k, num in enumerate(reversed(clues)):
+            x = (row_pad + j) * cell_size + 4
+            y = (col_pad - 1 - k) * cell_size + 4
+            draw.text((x, y), str(num), fill="black", font=font)
+
+    return img


### PR DESCRIPTION
## Summary
- create `clue_grid.py` to render puzzle clues as an image
- export `render_clue_grid` in batching output so each valid puzzle also saves a clue grid image

## Testing
- `pip install -r requirements.txt`
- `python test_solver.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68863bcfc3608327accfebfd7bd4e272