### PR TITLE
Improve clue grid rendering and puzzle trimming

### DIFF
--- a/clue_grid.py
+++ b/clue_grid.py
@@ -1,26 +1,52 @@
+"""Rendering utilities for nonogram clue grids."""
+
 from typing import List
 from PIL import Image, ImageDraw, ImageFont
 
 
-def render_clue_grid(row_clues: List[List[int]], col_clues: List[List[int]], cell_size: int = 20) -> Image.Image:
-    """Return an image visualizing the puzzle clues."""
+def render_clue_grid(
+    row_clues: List[List[int]],
+    col_clues: List[List[int]],
+    cell_size: int = 20,
+) -> Image.Image:
+    """Return an image visualizing the puzzle clues with nicer styling."""
     rows, cols = len(row_clues), len(col_clues)
     row_pad = max(len(c) for c in row_clues)
     col_pad = max(len(c) for c in col_clues)
 
-    width = (row_pad + cols) * cell_size
-    height = (col_pad + rows) * cell_size
-    img = Image.new("RGB", (width, height), "white")
+    grid_width = (row_pad + cols) * cell_size
+    grid_height = (col_pad + rows) * cell_size
+    pad = cell_size // 2  # extra space on bottom/right
+
+    img = Image.new("RGB", (grid_width + pad, grid_height + pad), "lavenderblush")
     draw = ImageDraw.Draw(img)
     font = ImageFont.load_default()
 
-    # Draw grid lines
+    # Dimensions label in the top-left corner
+    draw.text((4, 4), f"{rows}x{cols}", fill="darkblue", font=font)
+
+    def choose_color(idx: int, max_idx: int) -> str:
+        if idx == max_idx // 2:
+            return "mediumorchid"
+        if idx % 5 == 0:
+            return "darkviolet"
+        if idx % 2 == 0:
+            return "pink"
+        return "gray"
+
+    # Draw grid lines with alternating colors
     for i in range(rows + 1):
         y = (col_pad + i) * cell_size
-        draw.line([(row_pad * cell_size, y), (width, y)], fill="gray")
+        draw.line(
+            [(row_pad * cell_size, y), (grid_width, y)],
+            fill=choose_color(i, rows),
+        )
     for j in range(cols + 1):
         x = (row_pad + j) * cell_size
-        draw.line([(x, col_pad * cell_size), (x, height)], fill="gray")
+        draw.line(
+            [(x, col_pad * cell_size), (x, grid_height)],
+            fill=choose_color(j, cols),
+        )
 
     # Draw row clues
     for i, clues in enumerate(row_clues):

--- a/nonogram_clues.py
+++ b/nonogram_clues.py
@@ -18,6 +18,20 @@ def load_grid(path: str) -> np.ndarray:
     return (arr == 0).astype(np.uint8)
 
 
+def trim_grid(grid: np.ndarray) -> np.ndarray:
+    """Trim empty rows/columns from the borders of the grid."""
+    rows = np.any(grid, axis=1)
+    cols = np.any(grid, axis=0)
+    if not rows.any() or not cols.any():
+        return grid
+
+    top = rows.argmax()
+    bottom = len(rows) - rows[::-1].argmax()
+    left = cols.argmax()
+    right = len(cols) - cols[::-1].argmax()
+    return grid[top:bottom, left:right]
+
+
 def rle_line(line: np.ndarray) -> list:
     """Run-length encode a 1D binary array of a row or column."""
     clues = []
@@ -45,8 +59,13 @@ def extract_clues(grid: np.ndarray) -> tuple:
 
 def puzzle_from_image(path: str) -> NonogramPuzzle:
     grid = load_grid(path)
+    grid = trim_grid(grid)
     clues_row, clues_col = extract_clues(grid)
-    return NonogramPuzzle(clues_row=clues_row, clues_col=clues_col, grid_shape=grid.shape)
+    return NonogramPuzzle(
+        clues_row=clues_row,
+        clues_col=clues_col,
+        grid_shape=grid.shape,
+    )
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- trim empty rows and columns when generating puzzle clues
- stylize clue grid: alternating line colors, pastel background, dimension label, padding

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68863f0828088327ba798961bf73d22f