### PR TITLE
Show puzzle preview in clue grid

### DIFF
--- a/batching.py
+++ b/batching.py
@@ -51,7 +51,7 @@ def batch_process_images() -> None:
         return
 
     methods = [
-        {"name": "threshold", "args": ["--method", "threshold", "--threshold", "128"]},
+        # {"name": "threshold", "args": ["--method", "threshold", "--threshold", "128"]}, # TODO MAYBE ADD LATER
         {"name": "adaptive", "args": ["--method", "adaptive", "--block-size", "15", "--C", "3"]},
     ]
     grid_sizes = [50]
@@ -90,7 +90,7 @@ def batch_process_images() -> None:
                         clue_img = render_clue_grid(
                             puzzle.clues_row,
                             puzzle.clues_col,
-                            image_path=str(output_file),
+                            image_path=str(image_path),
                         )
                         clue_path = output_folder / f"{method_name}_grid{grid_size}_clues.png"
                         clue_img.save(clue_path)

--- a/batching.py
+++ b/batching.py
@@ -87,7 +87,11 @@ def batch_process_images() -> None:
                     subprocess.run(cmd, check=True, capture_output=True)
                     if validate_or_adapt(str(output_file)):
                         puzzle = puzzle_from_image(str(output_file))
-                        clue_img = render_clue_grid(puzzle.clues_row, puzzle.clues_col)
+                        clue_img = render_clue_grid(
+                            puzzle.clues_row,
+                            puzzle.clues_col,
+                            image_path=str(output_file),
+                        )
                         clue_path = output_folder / f"{method_name}_grid{grid_size}_clues.png"
                         clue_img.save(clue_path)
                     else:

--- a/clue_grid.py
+++ b/clue_grid.py
@@ -6,6 +6,7 @@ in the top-left corner beneath the dimensions label.
 
 from typing import List, Optional
 from PIL import Image, ImageDraw, ImageFont
+from PIL.Image import Resampling
 
 
 def render_clue_grid(
@@ -30,17 +31,18 @@ def render_clue_grid(
     # Dimensions label in the top-left corner
     draw.text((4, 4), f"{rows}x{cols}", fill="darkblue", font=font)
 
-    preview_y = font.getsize("A")[1] + 6
+    bbox = draw.textbbox((0, 0), "A", font=font)
+    preview_y = bbox[3] + 6
     if image_path:
         try:
             preview = Image.open(image_path).convert("RGB")
-            max_w = row_pad * cell_size - 8
+            max_w = row_pad * cell_size
             max_h = col_pad * cell_size - preview_y - 4
             if max_w > 5 and max_h > 5:
-                preview.thumbnail((max_w, max_h), Image.NEAREST)
+                preview.thumbnail((max_w, max_h), Resampling.NEAREST)
                 img.paste(preview, (4, preview_y))
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"Failed to load image preview from {image_path}: {e}")
 
     def choose_color(idx: int, max_idx: int) -> str:
         if idx == max_idx // 2:

--- a/clue_grid.py
+++ b/clue_grid.py
@@ -1,6 +1,10 @@
-"""Rendering utilities for nonogram clue grids."""
+"""Rendering utilities for nonogram clue grids.
 
-from typing import List
+`render_clue_grid` can optionally embed a preview of the puzzle image
+in the top-left corner beneath the dimensions label.
+"""
+
+from typing import List, Optional
 from PIL import Image, ImageDraw, ImageFont
 
 
@@ -8,6 +12,7 @@ def render_clue_grid(
     row_clues: List[List[int]],
     col_clues: List[List[int]],
     cell_size: int = 20,
+    image_path: Optional[str] = None,
 ) -> Image.Image:
     """Return an image visualizing the puzzle clues with nicer styling."""
     rows, cols = len(row_clues), len(col_clues)
@@ -24,6 +29,18 @@ def render_clue_grid(
 
     # Dimensions label in the top-left corner
     draw.text((4, 4), f"{rows}x{cols}", fill="darkblue", font=font)
+
+    preview_y = font.getsize("A")[1] + 6
+    if image_path:
+        try:
+            preview = Image.open(image_path).convert("RGB")
+            max_w = row_pad * cell_size - 8
+            max_h = col_pad * cell_size - preview_y - 4
+            if max_w > 5 and max_h > 5:
+                preview.thumbnail((max_w, max_h), Image.NEAREST)
+                img.paste(preview, (4, preview_y))
+        except Exception:
+            pass
 
     def choose_color(idx: int, max_idx: int) -> str:
         if idx == max_idx // 2:


### PR DESCRIPTION
## Summary
- embed puzzle image preview in generated clue grids
- pass puzzle path when rendering clue grids

## Testing
- `pip install -r requirements.txt`
- `python test_solver.py`

------
https://chatgpt.com/codex/tasks/task_e_688642019ccc8327907178957f90c3dc